### PR TITLE
Allow `and_group` and `or_group` dimension filters

### DIFF
--- a/src/Traits/FilterByDimensionTrait.php
+++ b/src/Traits/FilterByDimensionTrait.php
@@ -10,7 +10,7 @@ use Google\Analytics\Data\V1beta\FilterExpressionList;
 
 trait FilterByDimensionTrait
 {
-    public $dimensionFilter = null;
+    public ?FilterExpression $dimensionFilter = null;
 
     /**
      * Apply where dimension filter.

--- a/src/Traits/FilterByDimensionTrait.php
+++ b/src/Traits/FilterByDimensionTrait.php
@@ -6,10 +6,11 @@ use Google\Analytics\Data\V1beta\Filter;
 use Google\Analytics\Data\V1beta\Filter\InListFilter;
 use Google\Analytics\Data\V1beta\Filter\StringFilter;
 use Google\Analytics\Data\V1beta\FilterExpression;
+use Google\Analytics\Data\V1beta\FilterExpressionList;
 
 trait FilterByDimensionTrait
 {
-    public ?FilterExpression $dimensionFilter = null;
+    public $dimensionFilter = null;
 
     /**
      * Apply where dimension filter.
@@ -55,5 +56,64 @@ trait FilterByDimensionTrait
             ->setFilter($filter);
 
         return $this;
+    }
+
+    /**
+     * Apply where dimension filter using 'and_group'.
+     *
+     * @param array $dimensions
+     * @return $this
+     */
+    public function whereAndGroupDimensions($dimensions): self
+    {
+        $this->dimensionFilter = (new FilterExpression())->setAndGroup(
+            (new FilterExpressionList)
+                ->setExpressions(
+                    $this->createDimensionGroup($dimensions)
+                )
+        );
+
+        return $this;
+    }
+
+    /**
+     * Apply where dimension filter using 'or_group'.
+     *
+     * @param array $dimensions
+     * @return $this
+     */
+    public function whereOrGroupDimensions($dimensions): self
+    {
+        $this->dimensionFilter = (new FilterExpression())->setOrGroup(
+            (new FilterExpressionList)
+                ->setExpressions(
+                    $this->createDimensionGroup($dimensions)
+                )
+        );
+
+        return $this;
+    }
+
+    /**
+     * Create an array of dimension filters.
+     *
+     * @param array $dimensions
+     * @return void
+     */
+    protected function createDimensionGroup($dimensions): array
+    {
+        $filterExpressionList = [];
+
+        foreach ($dimensions as $dimension) {
+            $stringFilter = (new StringFilter())->setCaseSensitive($dimension[3] ?? false)
+                ->setMatchType($dimension[1])
+                ->setValue($dimension[2]);
+
+            $filter = (new Filter())->setStringFilter($stringFilter)->setFieldName($dimension[0]);
+
+            $filterExpressionList[] = (new FilterExpression())->setFilter($filter);
+        }
+
+        return $filterExpressionList;
     }
 }


### PR DESCRIPTION
Hi,

Thanks for this great package, it has been really helpful.

One thing that we didn't realise at first though is that you _can't_ add multiple dimension filters like this...

```php
LaravelGoogleAnalytics::dateRanges(Period::days(30), Period::days(60))
    ->metrics('sessions')
    ->dimensions('sessionCampaignName')
    ->whereDimension('sessionSource', MatchType::EXACT, 'Inbound')
    ->whereDimension('sessionCampaignName', MatchType::FULL_REGEXP, '^([0-9]+)')
    ->get();
```

In the above example, the first dimension filter gets overwritten by the second dimension filter.

To get around this, I have added 2 new methods to the `FilterByDimensionTrait` called `whereAndGroupDimensions()` and `whereOrGroupDimensions()`.

So, taking our above example, if we want the filter to match _**ALL**_ the specified dimensions, we can now do this...

```php
LaravelGoogleAnalytics::dateRanges(Period::days(30), Period::days(60))
    ->metrics('sessions')
    ->dimensions('sessionCampaignName')
    ->whereAndGroupDimensions([
        ['sessionSource', MatchType::EXACT, 'Inbound'],
        ['sessionCampaignName', MatchType::FULL_REGEXP, '^([0-9]+)'],
    )
    ->get();
```

...or, if we want the filter to match **_ANY_** of the specified dimensions, we can do this...

```php
LaravelGoogleAnalytics::dateRanges(Period::days(30), Period::days(60))
    ->metrics('sessions')
    ->dimensions('sessionCampaignName')
    ->whereOrGroupDimensions([
        ['sessionSource', MatchType::EXACT, 'Inbound'],
        ['sessionCampaignName', MatchType::FULL_REGEXP, '^([0-9]+)'],
    )
    ->get();
```

I haven't added any tests for this as it looks like your current test suite is doing real API requests to GA4 so I cannot see what data to query.

Would love to hear your thoughts on this, or any changes you may suggest.

Thanks 👍 