### PR TITLE
Allow `not` expressions

### DIFF
--- a/src/Traits/FilterByDimensionTrait.php
+++ b/src/Traits/FilterByDimensionTrait.php
@@ -95,6 +95,27 @@ trait FilterByDimensionTrait
     }
 
     /**
+     * Apply whereNot dimension filter.
+     *
+     * @return $this
+     */
+    public function whereNotDimension(string $name, int $matchType, $value, bool $caseSensitive = false): self
+    {
+        $stringFilter = (new StringFilter())->setCaseSensitive($caseSensitive)
+            ->setMatchType($matchType)
+            ->setValue($value);
+
+        $filter = (new Filter())->setStringFilter($stringFilter)
+            ->setFieldName($name);
+
+        $this->dimensionFilter = (new FilterExpression())->setNotExpression(
+            (new FilterExpression())->setFilter($filter)
+        );
+
+        return $this;
+    }
+
+    /**
      * Create an array of dimension filters.
      *
      * @param  array  $dimensions


### PR DESCRIPTION
We really needed to be able to do `not` expressions when running queries.

This PR allows you to do something like this...


```php
        return $this->metrics('sessions')
            ->dimensions('deviceCategory')
            ->whereDimensionIn('deviceCategory', ['desktop', 'tablet'])
            ->whereNotDimension('city', MatchType::EXACT, '(not set)');
            ->get();
```
